### PR TITLE
Add Funbuy ERC-20 token smart contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,54 @@
 # Funbuy Token
 
-This repository contains the Funbuy ERC-20 token contract (`contracts/FunbuyToken.sol`).
-The steps below walk you through deploying the token to Ethereum (or any EVM
-network) and then listing it for trading on Uniswap.
+`FunbuyToken.sol` implements a fixed-supply ERC-20 token with the following
+parameters:
 
-## 1. Deploy the contract with Remix
+| Property   | Value                          |
+| ---------- | ------------------------------ |
+| Name       | `Funbuy`                       |
+| Symbol     | `FUNBUY`                       |
+| Decimals   | `18`                           |
+| Total Supply | `1,260,000,000 FUNBUY` (minted to the deployer) |
 
-1. Go to [https://remix.ethereum.org](https://remix.ethereum.org) and create a new
-   file named `FunbuyToken.sol`. Paste in the contents of
-   [`contracts/FunbuyToken.sol`](contracts/FunbuyToken.sol).
-2. On the **Solidity Compiler** tab select compiler version `0.8.20` (or any
-   0.8.20+ build) and click **Compile FunbuyToken.sol**.
-3. Switch to the **Deploy & Run** tab.
-   - Environment: `Injected Provider - Metamask` (or another wallet provider)
-   - Account: the wallet that should receive the initial supply.
-   - Contract: `FunbuyToken`.
-4. Click **Deploy** and confirm the transaction in your wallet. The deploying
-   wallet receives the full `1_260_000_000 * 10^18` FUNBUY supply.
-5. After confirmation, copy the deployed contract address from Remix or from your
-   wallet's transaction history.
+The sections below describe how to deploy the contract, confirm the supply, and
+list the token on Uniswap so it can be traded from your application.
 
-## 2. Deploy with Hardhat (alternative CLI workflow)
+## Before you start
 
-1. Install dependencies in an empty folder:
+- Install [MetaMask](https://metamask.io/) (or another Web3 wallet) and fund the
+  deployment account with enough ETH to cover gas.
+- Decide which EVM network you want to deploy to (e.g. Ethereum mainnet,
+  Sepolia, Polygon, BNB Chain) and use the matching RPC URL in every step.
+- If you prefer a command-line workflow, make sure Node.js 18+ and npm are
+  installed.
+
+## 1. Deploy with Remix (browser workflow)
+
+1. Open [https://remix.ethereum.org](https://remix.ethereum.org) and create a new
+   file named `FunbuyToken.sol`.
+2. Copy the contents of
+   [`contracts/FunbuyToken.sol`](contracts/FunbuyToken.sol) into the new file.
+3. In the **Solidity Compiler** tab select version `0.8.20` (or any 0.8.20+
+   release) and press **Compile FunbuyToken.sol**.
+4. Switch to the **Deploy & Run** tab and configure:
+   - **Environment:** `Injected Provider - MetaMask` (or your wallet provider)
+   - **Account:** the wallet that should receive the entire supply
+   - **Contract:** `FunbuyToken`
+5. Click **Deploy** and confirm the transaction in your wallet. Once mined, the
+   deployer address holds the full `1,260,000,000 * 10^18` FUNBUY balance.
+6. Copy the deployed contract address from Remix or the transaction receipt and
+   save it—this is the address you will share with wallets, explorers, and
+   Uniswap.
+
+### Confirm the minted supply
+
+After deployment, expand the contract instance in Remix and read the `totalSupply`
+and `balanceOf(deployer)` values. They should both return
+`1260000000000000000000000000`, which is `1,260,000,000` FUNBUY with 18 decimals.
+
+## 2. Deploy with Hardhat (CLI workflow)
+
+1. Create an empty folder and install the dependencies:
 
    ```bash
    npm init -y
@@ -31,18 +57,19 @@ network) and then listing it for trading on Uniswap.
    ```
 
    When prompted, choose the **JavaScript project** template and let Hardhat
-   install the sample files.
+   write the starter files.
 
-2. Replace the contents of `contracts/Lock.sol` with the contents of
+2. Replace `contracts/Lock.sol` with the contents of
    [`contracts/FunbuyToken.sol`](contracts/FunbuyToken.sol).
-3. Create `.env` and store your RPC URL and deployer private key:
+
+3. Create `.env` and add your RPC URL and private key (never commit this file):
 
    ```dotenv
    RPC_URL="https://mainnet.infura.io/v3/<project-id>"
-   PRIVATE_KEY="0x..."
+   PRIVATE_KEY="0xYOUR_PRIVATE_KEY"
    ```
 
-4. Update `hardhat.config.js` to use the network you plan to deploy to:
+4. Update `hardhat.config.js`:
 
    ```js
    require("@nomicfoundation/hardhat-toolbox");
@@ -55,7 +82,7 @@ network) and then listing it for trading on Uniswap.
      networks: {
        mainnet: {
          url: RPC_URL,
-         accounts: [PRIVATE_KEY],
+         accounts: PRIVATE_KEY ? [PRIVATE_KEY] : [],
        },
      },
    };
@@ -69,8 +96,8 @@ network) and then listing it for trading on Uniswap.
    async function main() {
      const FunbuyToken = await hre.ethers.getContractFactory("FunbuyToken");
      const token = await FunbuyToken.deploy();
-
      await token.waitForDeployment();
+
      console.log("FunbuyToken deployed to:", await token.getAddress());
    }
 
@@ -80,54 +107,73 @@ network) and then listing it for trading on Uniswap.
    });
    ```
 
-6. Deploy:
+6. Deploy (replace `mainnet` with your desired network key):
 
    ```bash
    npx hardhat run scripts/deploy.js --network mainnet
    ```
 
-   The command prints the contract address once the transaction is mined.
+7. After the transaction is confirmed, record the address printed in the
+   terminal and verify the deployer balance with `npx hardhat console` if
+   desired:
 
-## 3. Verify the contract (optional but recommended)
+   ```bash
+   npx hardhat console --network mainnet
+   > const token = await ethers.getContractAt("FunbuyToken", "<contract-address>");
+   > (await token.totalSupply()).toString();
+   > (await token.balanceOf("<deployer-address>")).toString();
+   ```
 
-Verification lets explorers such as Etherscan show the source code.
+## 3. Verify the contract (recommended)
 
-- **Remix:** use the "Publish on verification services" checkbox when deploying,
-  or verify later on Etherscan by pasting the flattened source code.
-- **Hardhat:** install `@nomicfoundation/hardhat-verify` and run
-  `npx hardhat verify <contract-address>`.
+Contract verification lets explorers display the source code and ABI.
 
-## 4. Add the token to your wallet
+- **Remix:** check **Publish on verification services** during deployment or use
+  the **Sourcify / Etherscan** plugin afterward.
+- **Hardhat:** install the verify plugin and run the command with the compiler
+  arguments used during deployment:
 
-In MetaMask (or your preferred wallet) choose **Import Tokens** and paste the
-contract address. The wallet reads the token name, symbol, and decimals
-automatically.
+  ```bash
+  npm install --save-dev @nomicfoundation/hardhat-verify
+  npx hardhat verify --network mainnet <contract-address>
+  ```
 
-## 5. List on Uniswap
+## 4. Import the token in your wallet
 
-1. Go to the Uniswap interface (e.g. [https://app.uniswap.org](https://app.uniswap.org)).
-2. Connect the same wallet that holds the initial FUNBUY supply.
-3. Choose **Pool → New Position** (for v3) or **+ New Position** depending on the
-   interface version.
-4. In the token selector paste the FUNBUY contract address and click **Import**.
-5. Select the pair token (e.g. WETH or USDC) and choose your price range / fee tier.
-6. Enter the amount of FUNBUY and the paired asset you want to deposit, approve
-   the tokens, then supply liquidity.
+In MetaMask (or your preferred wallet) click **Import Tokens**, paste the
+contract address, and approve. The wallet auto-fills the name, symbol, and
+decimals from the chain.
 
-After liquidity is added, the token becomes tradable on Uniswap. Anyone can swap
-by importing the contract address in the token selector.
+## 5. Add liquidity on Uniswap
 
-## Troubleshooting
+1. Visit [https://app.uniswap.org](https://app.uniswap.org) and connect the
+   deployer wallet.
+2. Navigate to **Pool → New Position** (Uniswap v3) or **Pool → + New Position**.
+3. Paste the FUNBUY contract address, accept the import warning, and choose the
+   asset you want to pair with (WETH, USDC, etc.).
+4. Set your fee tier and price range (v3) or choose the appropriate pool type.
+5. Approve the FUNBUY and pair token if prompted, then supply the amounts you
+   want to seed as initial liquidity.
 
-- Confirm the deployer's wallet has enough ETH for gas.
-- Ensure you are using the correct network (testnet vs mainnet) consistently
-  across Remix/Hardhat, your wallet, and Uniswap.
-- If a deployment fails with `insufficient funds`, increase the gas limit or gas
-  price.
+Once liquidity is deposited, your token becomes discoverable on Uniswap. Share
+the contract address with users so they can import the token in the swap
+interface.
+
+## Troubleshooting checklist
+
+- Ensure the deployer wallet has enough native tokens for gas (deployment,
+  approvals, and liquidity supply each cost gas).
+- Verify that every tool (Remix/Hardhat, wallet, Uniswap) is pointed to the same
+  network.
+- If a transaction fails with `insufficient funds`, try raising the gas limit or
+  fee. For persistent failures, inspect the transaction in a block explorer for
+  detailed error messages.
+- If Uniswap cannot find the token, double-check that you are using the correct
+  contract address and that the deployment is confirmed on the network.
 
 ## Additional resources
 
-- [Ethereum Remix documentation](https://remix-ide.readthedocs.io)
-- [Hardhat getting started guide](https://hardhat.org/tutorial)
-- [Uniswap support docs](https://support.uniswap.org)
+- [Remix documentation](https://remix-ide.readthedocs.io)
+- [Hardhat guides](https://hardhat.org/tutorial)
+- [Uniswap help center](https://support.uniswap.org)
 

--- a/README.md
+++ b/README.md
@@ -1,120 +1,133 @@
-// SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <9.1.5;
+# Funbuy Token
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import "@openzeppelin/contracts/security/Pausable.sol";
+This repository contains the Funbuy ERC-20 token contract (`contracts/FunbuyToken.sol`).
+The steps below walk you through deploying the token to Ethereum (or any EVM
+network) and then listing it for trading on Uniswap.
 
-contract ECoin is ERC20, Ownable, ReentrancyGuard, Pausable {
-    // Total supply of the token
-    uint256 private constant INITIAL_SUPPLY = 1000000000000 * 10**decimals(); // 1 trillion tokens
+## 1. Deploy the contract with Remix
 
-    struct Stake {
-        uint256 amount;
-        uint256 timestamp;
-        uint256 rewards;
-    }
+1. Go to [https://remix.ethereum.org](https://remix.ethereum.org) and create a new
+   file named `FunbuyToken.sol`. Paste in the contents of
+   [`contracts/FunbuyToken.sol`](contracts/FunbuyToken.sol).
+2. On the **Solidity Compiler** tab select compiler version `0.8.20` (or any
+   0.8.20+ build) and click **Compile FunbuyToken.sol**.
+3. Switch to the **Deploy & Run** tab.
+   - Environment: `Injected Provider - Metamask` (or another wallet provider)
+   - Account: the wallet that should receive the initial supply.
+   - Contract: `FunbuyToken`.
+4. Click **Deploy** and confirm the transaction in your wallet. The deploying
+   wallet receives the full `1_260_000_000 * 10^18` FUNBUY supply.
+5. After confirmation, copy the deployed contract address from Remix or from your
+   wallet's transaction history.
 
-    // Mapping to store staking information per user
-    mapping(address => Stake) public stakes;
+## 2. Deploy with Hardhat (alternative CLI workflow)
 
-    // Reward rate (1 token for every 1 million tokens staked per hour)
-    uint256 public constant REWARD_RATE = 1 * 10**decimals() / 1_000_000; // 1 token per hour for 1 million staked
+1. Install dependencies in an empty folder:
 
-    // Events
-    event Staked(address indexed user, uint256 amount);
-    event Unstaked(address indexed user, uint256 amount);
-    event RewardsClaimed(address indexed user, uint256 amount);
+   ```bash
+   npm init -y
+   npm install --save-dev hardhat @nomicfoundation/hardhat-toolbox dotenv
+   npx hardhat
+   ```
 
-    // Constructor to initialize the token with the total supply
-    constructor() ERC20("ECoin", "ECN") {
-        _mint(msg.sender, INITIAL_SUPPLY); // Mint the total supply to the deployer's address
-    }
+   When prompted, choose the **JavaScript project** template and let Hardhat
+   install the sample files.
 
-    // Function to stake tokens
-    function stake(uint256 amount) public nonReentrant whenNotPaused {
-        require(amount > 0, "Amount should be greater than 0");
-        require(balanceOf(msg.sender) >= amount, "Insufficient balance to stake");
+2. Replace the contents of `contracts/Lock.sol` with the contents of
+   [`contracts/FunbuyToken.sol`](contracts/FunbuyToken.sol).
+3. Create `.env` and store your RPC URL and deployer private key:
 
-        // Update rewards before staking
-        updateRewards(msg.sender);
+   ```dotenv
+   RPC_URL="https://mainnet.infura.io/v3/<project-id>"
+   PRIVATE_KEY="0x..."
+   ```
 
-        // Transfer tokens to the contract for staking
-        _transfer(msg.sender, address(this), amount);
+4. Update `hardhat.config.js` to use the network you plan to deploy to:
 
-        // Update staking information
-        Stake storage userStake = stakes[msg.sender];
-        userStake.amount += amount;
-        userStake.timestamp = block.timestamp;
+   ```js
+   require("@nomicfoundation/hardhat-toolbox");
+   require("dotenv").config();
 
-        emit Staked(msg.sender, amount); // Emit Staked event
-    }
+   const { RPC_URL, PRIVATE_KEY } = process.env;
 
-    // Unstaking function
-    function unstake(uint256 amount) public nonReentrant whenNotPaused {
-        Stake storage userStake = stakes[msg.sender];
-        require(userStake.amount >= amount, "Insufficient staked balance to unstake");
+   module.exports = {
+     solidity: "0.8.20",
+     networks: {
+       mainnet: {
+         url: RPC_URL,
+         accounts: [PRIVATE_KEY],
+       },
+     },
+   };
+   ```
 
-        // Update rewards before unstaking
-        updateRewards(msg.sender);
+5. Add a deploy script `scripts/deploy.js`:
 
-        // Transfer staked tokens back to the user
-        userStake.amount -= amount;
-        _transfer(address(this), msg.sender, amount);
+   ```js
+   const hre = require("hardhat");
 
-        emit Unstaked(msg.sender, amount); // Emit Unstaked event
-    }
+   async function main() {
+     const FunbuyToken = await hre.ethers.getContractFactory("FunbuyToken");
+     const token = await FunbuyToken.deploy();
 
-    // Update rewards for a user
-    function updateRewards(address user) internal {
-        Stake storage userStake = stakes[user];
+     await token.waitForDeployment();
+     console.log("FunbuyToken deployed to:", await token.getAddress());
+   }
 
-        // Calculate how many hours have passed since the last update
-        uint256 hoursPassed = (block.timestamp - userStake.timestamp) / 1 hours;
+   main().catch((error) => {
+     console.error(error);
+     process.exitCode = 1;
+   });
+   ```
 
-        // Calculate the rewards earned
-        if (userStake.amount > 0 && hoursPassed > 0) {
-            // Rewards based on the amount staked and hours passed
-            uint256 earnedRewards = (userStake.amount * REWARD_RATE * hoursPassed) / 10**decimals();
-            userStake.rewards += earnedRewards;
-            userStake.timestamp = block.timestamp; // Reset the timestamp
-        }
-    }
+6. Deploy:
 
-    // Claim rewards function
-    function claimRewards() public nonReentrant whenNotPaused {
-        updateRewards(msg.sender); // Update rewards before claiming
+   ```bash
+   npx hardhat run scripts/deploy.js --network mainnet
+   ```
 
-        Stake storage userStake = stakes[msg.sender];
-        uint256 rewardsToClaim = userStake.rewards;
-        require(rewardsToClaim > 0, "No rewards to claim");
+   The command prints the contract address once the transaction is mined.
 
-        // Reset the rewards to zero and transfer the rewards to the user
-        userStake.rewards = 0;
-        _mint(msg.sender, rewardsToClaim); // Mint new tokens as rewards
+## 3. Verify the contract (optional but recommended)
 
-        emit RewardsClaimed(msg.sender, rewardsToClaim); // Emit RewardsClaimed event
-    }
+Verification lets explorers such as Etherscan show the source code.
 
-    // Function to view staked amount
-    function stakedAmount(address account) public view returns (uint256) {
-        return stakes[account].amount;
-    }
+- **Remix:** use the "Publish on verification services" checkbox when deploying,
+  or verify later on Etherscan by pasting the flattened source code.
+- **Hardhat:** install `@nomicfoundation/hardhat-verify` and run
+  `npx hardhat verify <contract-address>`.
 
-    // Function to view rewards
-    function viewRewards(address account) public view returns (uint256) {
-        return stakes[account].rewards;
-    }
+## 4. Add the token to your wallet
 
-    // Enable or disable contract functions (Pausable)
-    function pause() external onlyOwner {
-        _pause();
-    }
+In MetaMask (or your preferred wallet) choose **Import Tokens** and paste the
+contract address. The wallet reads the token name, symbol, and decimals
+automatically.
 
-    function unpause() external onlyOwner {
-        _unpause();
-    }
+## 5. List on Uniswap
 
-    // Transfer functions are inherited from ERC20
-}
+1. Go to the Uniswap interface (e.g. [https://app.uniswap.org](https://app.uniswap.org)).
+2. Connect the same wallet that holds the initial FUNBUY supply.
+3. Choose **Pool → New Position** (for v3) or **+ New Position** depending on the
+   interface version.
+4. In the token selector paste the FUNBUY contract address and click **Import**.
+5. Select the pair token (e.g. WETH or USDC) and choose your price range / fee tier.
+6. Enter the amount of FUNBUY and the paired asset you want to deposit, approve
+   the tokens, then supply liquidity.
+
+After liquidity is added, the token becomes tradable on Uniswap. Anyone can swap
+by importing the contract address in the token selector.
+
+## Troubleshooting
+
+- Confirm the deployer's wallet has enough ETH for gas.
+- Ensure you are using the correct network (testnet vs mainnet) consistently
+  across Remix/Hardhat, your wallet, and Uniswap.
+- If a deployment fails with `insufficient funds`, increase the gas limit or gas
+  price.
+
+## Additional resources
+
+- [Ethereum Remix documentation](https://remix-ide.readthedocs.io)
+- [Hardhat getting started guide](https://hardhat.org/tutorial)
+- [Uniswap support docs](https://support.uniswap.org)
+

--- a/contracts/FunbuyToken.sol
+++ b/contracts/FunbuyToken.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Funbuy Token
+/// @notice Basic ERC-20 implementation for the Funbuy token with a fixed supply.
+contract FunbuyToken {
+    string public constant name = "Funbuy";
+    string public constant symbol = "FUNBUY";
+    uint8 public constant decimals = 18;
+
+    uint256 public immutable totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor() {
+        uint256 initialSupply = 1_260_000_000 * 10 ** uint256(decimals);
+        totalSupply = initialSupply;
+        balanceOf[msg.sender] = initialSupply;
+        emit Transfer(address(0), msg.sender, initialSupply);
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _approve(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        if (allowed != type(uint256).max) {
+            require(allowed >= value, "ERC20: insufficient allowance");
+            allowance[from][msg.sender] = allowed - value;
+        }
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function increaseAllowance(address spender, uint256 addedValue) external returns (bool) {
+        _approve(msg.sender, spender, allowance[msg.sender][spender] + addedValue);
+        return true;
+    }
+
+    function decreaseAllowance(address spender, uint256 subtractedValue) external returns (bool) {
+        uint256 currentAllowance = allowance[msg.sender][spender];
+        require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
+        _approve(msg.sender, spender, currentAllowance - subtractedValue);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        require(to != address(0), "ERC20: transfer to the zero address");
+
+        uint256 fromBalance = balanceOf[from];
+        require(fromBalance >= value, "ERC20: transfer amount exceeds balance");
+        unchecked {
+            balanceOf[from] = fromBalance - value;
+        }
+        balanceOf[to] += value;
+
+        emit Transfer(from, to, value);
+    }
+
+    function _approve(address owner, address spender, uint256 value) internal {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        allowance[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+}


### PR DESCRIPTION
## Summary
- add a standalone Funbuy ERC-20 token contract with a fixed 1.26 billion token supply minted to the deployer
- include standard transfer and allowance helper functions for DEX compatibility

## Testing
- not run (contract only)

------
https://chatgpt.com/codex/tasks/task_e_68e6a7713f3c83329ebd9341aff741e0